### PR TITLE
이미지 재생 애니메이션 비동기 처리

### DIFF
--- a/client-mobile/DustApp/DustApp/Views/Forecast/ForecastImageView.swift
+++ b/client-mobile/DustApp/DustApp/Views/Forecast/ForecastImageView.swift
@@ -28,14 +28,13 @@ class ForecastImageView: UIImageView {
     
     private func play() {
         isPlaying = true
-        UIView.transition(with: self, duration: durationTime, options: .transitionCrossDissolve, animations: {
-            self.viewModel?.index += 1
-            self.image = self.viewModel?.image(at: self.viewModel!.index)
-        }, completion: { _ in
+        viewModel?.index += 1
+        image = viewModel?.image(at: viewModel!.index)
+        DispatchQueue.main.asyncAfter(deadline: .now() + durationTime) {
             if self.isPlaying {
                 self.play()
             }
-        })
+        }
     }
     
     private func pause() {

--- a/client-mobile/DustApp/DustApp/Views/Forecast/ForecastImageView.swift
+++ b/client-mobile/DustApp/DustApp/Views/Forecast/ForecastImageView.swift
@@ -12,7 +12,7 @@ class ForecastImageView: UIImageView {
     
     var viewModel: ForecastViewModel?
     private let durationTime: Double = 1
-    var isPlaying: Bool = false
+    private var isPlaying: Bool = false
     
     func configureImage(image: UIImage?) {
         self.image = image


### PR DESCRIPTION
기존에 `UIView.transition`을 사용하여 구현했던 부분을 `DispatchQueue.main.asynAfter`을 사용하여 구현하였습니다.
그런데 이렇게 하면 재생을 연속해서 멈췄다 재생했다를 반복하면 비동기로 처리하여 여러번 이미지가 바뀌어버리는데, 이를 보안할 수 있을까요? 아니면 비동기를 사용하는게 적절하지 못하나요?